### PR TITLE
Prepare for editor, deal with no parameters

### DIFF
--- a/lib/blinkbox/swaggerific/service.rb
+++ b/lib/blinkbox/swaggerific/service.rb
@@ -193,6 +193,7 @@ module Blinkbox
               value = given_query_params[param["name"]] || param["default"]
               accumulator.merge!(param["name"] => value) unless value.nil?
             end
+            accumulator
           end
           required_get_params = (operation["parameters"] || []).map { |param|
             param["name"] if param["in"] == "query" && param["required"] == true

--- a/lib/blinkbox/swaggerific/uploader_service.rb
+++ b/lib/blinkbox/swaggerific/uploader_service.rb
@@ -25,8 +25,8 @@ module Blinkbox
               ) if env['REQUEST_PATH'] =~ %r{^/swag/}
               send_file(
                 Regexp.last_match[1],
-                root: "swagger-ui/dist"
-              ) if env['REQUEST_PATH'] =~ %r{^/swagger-ui(/.*)$}
+                root: "editor"
+              ) if env['REQUEST_PATH'] =~ %r{^/editor(/.*)$}
               send_file(env['REQUEST_PATH'], accept: env['HTTP_ACCEPT'])
             when "post"
               halt(404) unless env['REQUEST_PATH'] == "/swag"


### PR DESCRIPTION
Fixes a bug where no specified parameters will break the path matcher.
