### PR TITLE
Docker (CentOS 7)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gitignore
+.travis.yml
+spec
+.rspec

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,28 @@
-###############################################
+########################################
 #
-# Docker file to build a standalone swaggerific
+# Runs swaggerific with puma on CentOS 7
 #
-###############################################
+########################################
 
 FROM centos:centos7
 
 MAINTAINER Drew J. Sonne drews@blinkbox.com
 
-RUN yum update -y
-RUN yum install unzip wget bundle ruby-devel make gcc openssl-devel -y
-RUN gem install foreman
-RUN gem install bundler
+RUN yum update -y && yum install -y \
+  unzip \
+  wget \
+  bundle \
+  ruby-devel \
+  make \
+  gcc \
+  openssl-devel
+RUN gem install foreman bundler
+
+COPY Gemfile /srv/www/swaggerific/
+COPY Gemfile.lock /srv/www/swaggerific/
+WORKDIR /srv/www/swaggerific
+RUN bundle install --deployment --without test,development
+COPY . /srv/www/swaggerific
 
 EXPOSE 5000
-
-ADD . /srv/www/swaggerific
-WORKDIR /srv/www/swaggerific
-RUN bundle install
-
-ENV SWAGGERIFIC_TLD_LEVEL 4
-
-ADD ./swaggerific /usr/local/bin/swaggerific
-RUN chmod ug+rx,ugo-w,o-rx /usr/local/bin/swaggerific
+ENTRYPOINT ["foreman", "start"]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ foreman start -p 5000
 git clone https://github.com/blinkboxbooks/swaggerific.git
 cd swaggerific
 docker build -t swaggerific .
-docker run -d -t -p 5000:5000 swaggerific swaggerific
+docker run -dt -p 5000:5000 swaggerific
 ```
 
 ### Getting going on Heroku

--- a/swaggerific
+++ b/swaggerific
@@ -1,3 +1,0 @@
-#! /bin/bash
-cd /srv/www/swaggerific
-foreman start -p 5000


### PR DESCRIPTION
### New Feature
- Includes @drewsonne's PR #15 to bring Docker support (with CentOS 7 + ruby 2.0.0p353) - thanks Drew!
- Modifications of `Dockerfile` to increase use of docker cache
- Included `.dockerignore` to reduce size of container
- Used `ENTRYPOINT` to remove need for separate executable
- Still to do: remove development libraries & clean up after bundle install.
