### PR TITLE
Array UniqueItems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "genny", "~> 0.2", ">= 0.2.2"
+gem "genny", "~> 0.4", ">= 0.4.2"
 gem "faker"
 gem "rack"
 gem "json-schema"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
     diff-lcs (1.2.5)
     faker (1.4.3)
       i18n (~> 0.5)
-    genny (0.4.1)
+    genny (0.4.2)
     i18n (0.6.11)
     json (1.8.1)
     json-schema (2.4.1)
@@ -43,7 +43,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   faker
-  genny (~> 0.2, >= 0.2.2)
+  genny (~> 0.4, >= 0.4.2)
   json-schema
   puma
   rack


### PR DESCRIPTION
### Bugfix
- Upgrade to Genny `0.4.2` to cover arrays with `uniqueItems: true`.
