### PR TITLE
protect and forward the www domain

### DIFF
--- a/lib/blinkbox/swaggerific/service.rb
+++ b/lib/blinkbox/swaggerific/service.rb
@@ -25,7 +25,7 @@ module Blinkbox
             # Multi service mode
             idx = (@@tld_level + 1) * -1
             filename_or_subdomain = env['HTTP_HOST'].split(".")[0..idx].join(".")
-            return UploaderService.call(env) if filename_or_subdomain == ""
+            return UploaderService.call(env) if ["", "www"].include? filename_or_subdomain
           else
             # Single service mode
             filename_or_subdomain = @@swagger_store

--- a/lib/blinkbox/swaggerific/uploader_service.rb
+++ b/lib/blinkbox/swaggerific/uploader_service.rb
@@ -19,10 +19,12 @@ module Blinkbox
           content_type :json
           subdomain.downcase!
 
-          halt(400, {
-            "error" => "disallowed_subdomain",
-            "message" => "You cannot change the meta subdomain"
-          }.to_json) if subdomain == "meta"
+          %w{www meta}.each do |restricted_domain|
+            halt(400, {
+              "error" => "disallowed_subdomain",
+              "message" => "You cannot change the #{restricted_domain} subdomain"
+            }.to_json) if subdomain == restricted_domain
+          end
 
           halt(400, {
             "error" => "disallowed_subdomain",


### PR DESCRIPTION
### New feature

- Allo the `www` subdomain to be used as an equivalent of the root domain, for DNS hosts which don't support root `ALIAS` or `ANAME` records. I'm looking at you GoDaddy.